### PR TITLE
Python デプロイ時の挙動・API Management 登録時の HTTP メソッド指定に関する修正

### DIFF
--- a/src/Python/Api1/function_app.py
+++ b/src/Python/Api1/function_app.py
@@ -1,14 +1,14 @@
 import azure.functions as func
-import logging
-import os
-import pyodbc
-import product as p
-import json
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
-@app.route(route="GetProduct")
+@app.route(route="GetProduct", methods=("GET",))
 def GetProduct(req: func.HttpRequest) -> func.HttpResponse:
+    import logging
+    import os
+    import pyodbc
+    import product as p
+    import json
     logging.info('Python HTTP trigger function processed a request.')
 
     id = req.params.get('id')


### PR DESCRIPTION
## 対応内容

- `No HTTP triggers found` エラーに対応。
- API Management 登録時の HTTP メソッドを既定で GET にする修正対応。

参考: https://github.com/microsoft/Oryx/issues/1774#issuecomment-1671958417

以下の形式ではなく、

```
import azure.functions as func

from src.mypckg import foo
# ... other imports

app = func.FunctionApp()

@app.function_name('myfunction')
async def main(...)
    ...
   
```

この形式に書き換えた。

```
import azure.functions as func

app = func.FunctionApp()

@app.function_name('myfunction')
async def main(...)
    # YOUR IMPORTS HERE <--
    from src.mypckg import foo
    # ... other imports
    ...
```

また、API Management 登録時の HTTP メソッドとして GET を指定するよう修正した。

<img width="577" alt="image" src="https://github.com/hiroyay-ms/Serverless-Computing-using-Azure-Functions/assets/38392404/75358e8a-77e0-49f9-bd5b-016d54cb521c">
